### PR TITLE
feat: token container

### DIFF
--- a/ape_tokens/__init__.py
+++ b/ape_tokens/__init__.py
@@ -1,8 +1,16 @@
 from ape import plugins
 
 from .converters import TokenConversions
+from .managers import TokenManager as _TokenManager
 
 
 @plugins.register(plugins.ConversionPlugin)
 def converters():
     yield int, TokenConversions
+
+
+tokens = _TokenManager()
+
+__all__ = [
+    "tokens",
+]

--- a/ape_tokens/managers.py
+++ b/ape_tokens/managers.py
@@ -1,0 +1,65 @@
+from ape.api import AddressAPI
+from ape.types import ContractType
+from ape.utils import cached_property
+from eth_utils import to_checksum_address
+from tokenlists import TokenListManager
+
+ERC20 = ContractType.from_dict(
+    {
+        "contractName": "ERC20",  # type: ignore
+        "abi": [
+            {
+                "type": "function",
+                "stateMutability": "view",
+                "name": "name",
+                "outputs": [{"type": "string"}],
+            },
+            {
+                "type": "function",
+                "stateMutability": "view",
+                "name": "symbol",
+                "outputs": [{"type": "string"}],
+            },
+            {
+                "type": "function",
+                "stateMutability": "view",
+                "name": "decimals",
+                "outputs": [{"type": "uint8"}],
+            },
+            {
+                "type": "function",
+                "stateMutability": "view",
+                "name": "totalSupply",
+                "outputs": [{"type": "uint256"}],
+            },
+            {
+                "type": "function",
+                "stateMutability": "view",
+                "name": "balanceOf",
+                "inputs": [{"name": "holder", "type": "address"}],
+                "outputs": [{"type": "uint256"}],
+            },
+        ],
+    }
+)
+
+
+class TokenManager(dict):
+    @cached_property
+    def _manager(self) -> TokenListManager:
+        return TokenListManager()
+
+    @cached_property
+    def _Contract(self):
+        from ape import Contract
+
+        return Contract
+
+    def __getitem__(self, symbol: str) -> AddressAPI:
+        try:
+            token_info = self._manager.get_token_info(symbol)
+
+        except ValueError as e:
+            raise KeyError(f"Symbol '{symbol}' is not a known token symbol") from e
+
+        return self._Contract(to_checksum_address(token_info.address), contract_type=ERC20)


### PR DESCRIPTION
### What I did

Add `tokens` container object, that allows accessing the token ERC20 contracts for installed tokenlists. This helpful shortcut allows working with mainnet tokenlists out of the box.

### How I did it

### How to verify it

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
