### PR TITLE
fix: replace from_dict with init

### DIFF
--- a/ape_tokens/managers.py
+++ b/ape_tokens/managers.py
@@ -4,8 +4,8 @@ from ape.utils import cached_property
 from eth_utils import to_checksum_address
 from tokenlists import TokenListManager
 
-ERC20 = ContractType.from_dict(
-    {
+ERC20 = ContractType(
+    **{
         "contractName": "ERC20",  # type: ignore
         "abi": [
             {

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setup(
     python_requires=">=3.7, <4",
     install_requires=[
         "importlib-metadata ; python_version<'3.8'",
-        "eth-ape>=0.1.0b2",
+        "eth-ape>=0.1.0b4",
         "tokenlists>=0.1.1",
     ],
     entry_points={


### PR DESCRIPTION
### What I did

Handle updates from `ape` regarding `ethpm-types` dependency change.
**Required release of ape after https://github.com/ApeWorX/ape/pull/408 merges**

### How I did it

Replace `from_dict` with a normal init and a dict decoupling `**`

### How to verify it

Install

```bash
ape plugins add tokens
```

then do 

```bash
ape
```

The tokens command should load be listed successfully.

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
