### PR TITLE
chore: update pin to ape v0.4.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v4.2.0
     hooks:
     -   id: check-yaml
 
@@ -10,21 +10,22 @@ repos:
       - id: isort
 
 -   repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 22.6.0
     hooks:
       - id: black
         name: black
 
 -   repo: https://gitlab.com/pycqa/flake8
-    rev: 3.9.2
+    rev: 4.0.1
     hooks:
     -   id: flake8
 
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.950
+    rev: v0.971
     hooks:
     -   id: mypy
+        additional_dependencies: [types-PyYAML, types-requests]
 
 
 default_language_version:
-    python: python3
+    python: python3.8

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A series of utilities for working with tokens, based on the [`py-tokenlists`](ht
 
 ## Dependencies
 
-* [python3](https://www.python.org/downloads) version 3.7 or greater, python3-dev
+* [python3](https://www.python.org/downloads) version 3.7.2 or greater, python3-dev
 
 ## Installation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ write_to = "ape_tokens/version.py"
 
 [tool.black]
 line-length = 100
-target-version = ['py37', 'py38', 'py39']
+target-version = ['py37', 'py38', 'py39', 'py310']
 include = '\.pyi?$'
 
 [tool.pytest.ini_options]

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setup(
     python_requires=">=3.7.2, <4",
     install_requires=[
         "importlib-metadata ; python_version<'3.8'",
-        "eth-ape>=0.3.0,<0.4.0",
+        "eth-ape>=0.4.0,<0.5.0",
         "tokenlists>=0.1.1",
     ],
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -5,15 +5,15 @@ from setuptools import find_packages, setup  # type: ignore
 
 extras_require = {
     "test": [  # `test` GitHub Action jobs uses this
-        "pytest>=6.0,<7.0",  # Core testing package
+        "pytest>=6.0",  # Core testing package
         "pytest-xdist",  # multi-process runner
         "pytest-cov",  # Coverage analyzer plugin
         "hypothesis>=6.2.0,<7.0",  # Strategy-based fuzzer
     ],
     "lint": [
-        "black>=22.3.0,<23.0",  # auto-formatter and linter
-        "mypy>=0.950,<1.0",  # Static type analyzer
-        "flake8>=3.9.2,<4.0",  # Style linter
+        "black>=22.6.0,<23.0",  # auto-formatter and linter
+        "mypy>=0.971,<1.0",  # Static type analyzer
+        "flake8>=4.0.1,<5.0",  # Style linter
         "isort>=5.10.1,<6.0",  # Import sorting linter
     ],
     "doc": [
@@ -58,7 +58,7 @@ setup(
     author_email="admin@apeworx.io",
     url="https://github.com/ApeWorX/ape-tokens",
     include_package_data=True,
-    python_requires=">=3.7.2, <4",
+    python_requires=">=3.7.2,<4",
     install_requires=[
         "importlib-metadata ; python_version<'3.8'",
         "eth-ape>=0.4.0,<0.5.0",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import pytest
+from click.testing import CliRunner
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,11 +1,4 @@
-import pytest
 from ape._cli import cli
-from click.testing import CliRunner
-
-
-@pytest.fixture
-def runner():
-    return CliRunner()
 
 
 def test_help(runner):


### PR DESCRIPTION
### What I did
update pins for ape v0.4.0

### How I did it
update setup.py

### How to verify it
github checks

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
