### PR TITLE
fix: use chain ID [APE-1201]

### DIFF
--- a/ape_tokens/managers.py
+++ b/ape_tokens/managers.py
@@ -118,7 +118,9 @@ class TokenManager(ManagerAccessMixin, dict):
 
     def __getitem__(self, symbol: str) -> ContractInstance:
         try:
-            token_info = self._manager.get_token_info(symbol)
+            token_info = self._manager.get_token_info(
+                symbol, chain_id=self.network_manager.network.chain_id
+            )
 
         except ValueError as e:
             raise KeyError(f"Symbol '{symbol}' is not a known token symbol") from e

--- a/ape_tokens/managers.py
+++ b/ape_tokens/managers.py
@@ -1,6 +1,6 @@
-from ape.api import Address
+from ape.contracts import ContractInstance
 from ape.types import ContractType
-from ape.utils import cached_property
+from ape.utils import ManagerAccessMixin, cached_property
 from eth_utils import to_checksum_address
 from tokenlists import TokenListManager
 
@@ -105,7 +105,7 @@ ERC20 = ContractType(
 )
 
 
-class TokenManager(dict):
+class TokenManager(ManagerAccessMixin, dict):
     @cached_property
     def _manager(self) -> TokenListManager:
         return TokenListManager()
@@ -116,11 +116,13 @@ class TokenManager(dict):
 
         return Contract
 
-    def __getitem__(self, symbol: str) -> Address:
+    def __getitem__(self, symbol: str) -> ContractInstance:
         try:
             token_info = self._manager.get_token_info(symbol)
 
         except ValueError as e:
             raise KeyError(f"Symbol '{symbol}' is not a known token symbol") from e
 
-        return self._Contract(to_checksum_address(token_info.address), contract_type=ERC20)
+        return self.chain_manager.contracts.instance_at(
+            to_checksum_address(token_info.address), contract_type=ERC20
+        )


### PR DESCRIPTION
### What I did

Some tokenlists contain the same symbol on different chains, like USDC:

```py
$ ape console --network :mainnet:alchemy

In [1]: from ape_tokens import tokens

In [2]: tokens["USDC"]
Out[2]: <ERC20 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48>

In [3]: with networks.arbitrum.mainnet.use_provider("alchemy"):
   ...:     print(tokens["USDC"])
   ...: 
0xaf88d065e77c8cC2239327C5EDb3A432268e5831
```

### How I did it

### How to verify it

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
~~- [x] Documentation has been updated~~
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
