### PR TITLE
fix: weird repr of token manager [APE-1241]

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.2.0
+    rev: v4.4.0
     hooks:
     -   id: check-yaml
 
@@ -10,7 +10,7 @@ repos:
       - id: isort
 
 -   repo: https://github.com/psf/black
-    rev: 23.3.0
+    rev: 23.7.0
     hooks:
       - id: black
         name: black
@@ -21,13 +21,13 @@ repos:
     -   id: flake8
 
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.991
+    rev: v1.4.1
     hooks:
     -   id: mypy
         additional_dependencies: [types-setuptools, pydantic]
 
 -   repo: https://github.com/executablebooks/mdformat
-    rev: 0.7.14
+    rev: 0.7.16
     hooks:
     -   id: mdformat
         additional_dependencies: [mdformat-gfm, mdformat-frontmatter]

--- a/ape_tokens/managers.py
+++ b/ape_tokens/managers.py
@@ -110,11 +110,8 @@ class TokenManager(ManagerAccessMixin, dict):
     def _manager(self) -> TokenListManager:
         return TokenListManager()
 
-    @cached_property
-    def _Contract(self):
-        from ape import Contract
-
-        return Contract
+    def __repr__(self) -> str:
+        return "<ape_tokens.TokenManager>"
 
     def __getitem__(self, symbol: str) -> ContractInstance:
         try:

--- a/setup.py
+++ b/setup.py
@@ -11,8 +11,8 @@ extras_require = {
         "hypothesis>=6.2.0,<7.0",  # Strategy-based fuzzer
     ],
     "lint": [
-        "black>=23.3.0,<24",  # auto-formatter and linter
-        "mypy>=0.991,<1",  # Static type analyzer
+        "black>=23.7.0,<24",  # auto-formatter and linter
+        "mypy>=0.991",  # Static type analyzer
         "types-setuptools",  # Needed due to mypy typeshed
         "flake8>=6.0.0,<7",  # Style linter
         "isort>=5.10.1,<6",  # Import sorting linter


### PR DESCRIPTION
### What I did

The `TokenManager`'s repr is just `{}` which is kinda weird, makes it seem like you don't have any tokenlists installed or something even though that is not the case. Better to just use `<ape_tokens.TokenManager>` so that is what this PR does.

P.s. trying to figure out how to get USD of tokens

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
