### PR TITLE
fix: use `ape.Contract` before default ERC20 contract type

### DIFF
--- a/ape_tokens/managers.py
+++ b/ape_tokens/managers.py
@@ -123,9 +123,10 @@ class TokenManager(ManagerAccessMixin, dict):
         except ValueError as err:
             raise KeyError(f"Symbol '{symbol}' is not a known token symbol") from err
 
+        checksummed_address = to_checksum_address(token_info.address)
         try:
-            return self.chain_manager.contracts.instance_at(to_checksum_address(token_info.address))
+            return self.chain_manager.contracts.instance_at(checksummed_address)
         except ContractNotFoundError:
             return self.chain_manager.contracts.instance_at(
-                to_checksum_address(token_info.address), contract_type=ERC20
+                checksummed_address, contract_type=ERC20
             )

--- a/ape_tokens/managers.py
+++ b/ape_tokens/managers.py
@@ -1,4 +1,5 @@
 from ape.contracts import ContractInstance
+from ape.exceptions import ContractNotFoundError
 from ape.types import ContractType
 from ape.utils import ManagerAccessMixin, cached_property
 from eth_utils import to_checksum_address
@@ -122,6 +123,9 @@ class TokenManager(ManagerAccessMixin, dict):
         except ValueError as err:
             raise KeyError(f"Symbol '{symbol}' is not a known token symbol") from err
 
-        return self.chain_manager.contracts.instance_at(
-            to_checksum_address(token_info.address), contract_type=ERC20
-        )
+        try:
+            return self.chain_manager.contracts.instance_at(to_checksum_address(token_info.address))
+        except ContractNotFoundError:
+            return self.chain_manager.contracts.instance_at(
+                to_checksum_address(token_info.address), contract_type=ERC20
+            )

--- a/ape_tokens/managers.py
+++ b/ape_tokens/managers.py
@@ -112,7 +112,7 @@ class TokenManager(ManagerAccessMixin, dict):
         return TokenListManager()
 
     def __repr__(self) -> str:
-        return "<ape_tokens.TokenManager>"
+        return f"<ape_tokens.TokenManager default='{self._manager.default_tokenlist}'>"
 
     def __getitem__(self, symbol: str) -> ContractInstance:
         try:


### PR DESCRIPTION
### What I did

Use explorer by default, unless it has an error finding the contract, then default to built-in ERC20 contract type interface

fixes: #8

### How I did it

### How to verify it

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
~~- [ ] New test cases have been added and are passing~~
~~- [ ] Documentation has been updated~~
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
