### PR TITLE
perf: lazy load so `ape --help` is still fast

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -62,9 +62,7 @@ jobs:
 
         strategy:
             matrix:
-                # TODO: Replace with macos-latest when works again.
-                #   https://github.com/actions/setup-python/issues/808
-                os: [ubuntu-latest, macos-12]   # eventually add `windows-latest`
+                os: [ubuntu-latest, macos-latest]   # eventually add `windows-latest`
                 python-version: [3.9, "3.10", "3.11", "3.12"]
 
         steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
     -   id: check-yaml
 
@@ -10,24 +10,24 @@ repos:
       - id: isort
 
 -   repo: https://github.com/psf/black
-    rev: 24.4.2
+    rev: 24.10.0
     hooks:
       - id: black
         name: black
 
 -   repo: https://github.com/pycqa/flake8
-    rev: 7.0.0
+    rev: 7.1.1
     hooks:
     -   id: flake8
 
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.10.0
+    rev: v1.13.0
     hooks:
     -   id: mypy
         additional_dependencies: [types-setuptools, pydantic]
 
 -   repo: https://github.com/executablebooks/mdformat
-    rev: 0.7.17
+    rev: 0.7.18
     hooks:
     -   id: mdformat
         additional_dependencies: [mdformat-gfm, mdformat-frontmatter, mdformat-pyproject]

--- a/ape_tokens/__init__.py
+++ b/ape_tokens/__init__.py
@@ -1,17 +1,34 @@
-from ape import plugins
-from ape.types import AddressType
+from typing import Any
 
-from .converters import TokenAmountConverter, TokenSymbolConverter
-from .managers import TokenManager as _TokenManager
+from ape import plugins
+from ape.types.address import AddressType
 
 
 @plugins.register(plugins.ConversionPlugin)
 def converters():
+    from .converters import TokenAmountConverter, TokenSymbolConverter
+
     yield int, TokenAmountConverter
     yield AddressType, TokenSymbolConverter
 
 
-tokens = _TokenManager()
+tokens = None  # NOTE: Initialized lazily
+
+
+def __getattr__(name: str) -> Any:
+    if name == "tokens":
+
+        global tokens
+        if tokens is None:
+            from .managers import TokenManager as _TokenManager
+
+            tokens = _TokenManager()
+
+        return tokens
+
+    else:
+        raise AttributeError(name)
+
 
 __all__ = [
     "tokens",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ include = '\.pyi?$'
 [tool.pytest.ini_options]
 addopts = """
     -p no:ape_test
+    -p no:pytest_ethereum
     --cov-branch
     --cov-report term
     --cov-report html

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,6 @@
 [flake8]
 max-line-length = 100
+ignore = E704,W503,PYD002
 exclude =
 	venv*
 	.tox

--- a/setup.py
+++ b/setup.py
@@ -10,12 +10,12 @@ extras_require = {
         "hypothesis>=6.2.0,<7.0",  # Strategy-based fuzzer
     ],
     "lint": [
-        "black>=24.4.2,<25",  # Auto-formatter and linter
-        "mypy>=1.10.0,<2",  # Static type analyzer
+        "black>=24.10.0,<25",  # Auto-formatter and linter
+        "mypy>=1.13.0,<2",  # Static type analyzer
         "types-setuptools",  # Needed for mypy type shed
-        "flake8>=7.0.0,<8",  # Style linter
+        "flake8>=7.1.1,<8",  # Style linter
         "isort>=5.13.2,<6",  # Import sorting linter
-        "mdformat>=0.7.17",  # Auto-formatter for markdown
+        "mdformat>=0.7.18",  # Auto-formatter for markdown
         "mdformat-gfm>=0.3.5",  # Needed for formatting GitHub-flavored markdown
         "mdformat-frontmatter>=0.4.1",  # Needed for frontmatters-style headers in issue templates
         "mdformat-pyproject>=0.0.1",  # Allows configuring in pyproject.toml


### PR DESCRIPTION
### What I did

needed to make `ape --help` still load fast when this plugin is installed.
base = https://github.com/ApeWorX/ape/pull/2333


### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
