### PR TITLE
refactor: short-circuit immutable contract calls

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,9 +13,6 @@ jobs:
     linting:
         runs-on: ubuntu-latest
 
-        env:
-          GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
         steps:
         - uses: actions/checkout@v4
 
@@ -67,6 +64,9 @@ jobs:
             matrix:
                 os: [ubuntu-latest, macos-latest]   # eventually add `windows-latest`
                 python-version: [3.9, "3.10", "3.11", "3.12", "3.13"]
+
+        env:
+          GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
         steps:
         - uses: actions/checkout@v4

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -68,8 +68,11 @@ jobs:
         steps:
         - uses: actions/checkout@v4
 
-        - name: Setup Python
-          uses: actions/setup-python@v5
+        - name: Install Foundry
+          uses: foundry-rs/foundry-toolchain@v1
+
+        - name: Install Ape
+          uses: ApeWorX/github-action@v3
           with:
               python-version: ${{ matrix.python-version }}
 
@@ -79,7 +82,7 @@ jobs:
             pip install .[test]
 
         - name: Run Tests
-          run: pytest -m "not fuzzing" -n 0 -s --cov
+          run: ape test -m "not fuzzing" -n 0 -s --cov
 
 # NOTE: uncomment this block after you've marked tests with @pytest.mark.fuzzing
 #    fuzzing:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,6 +13,9 @@ jobs:
     linting:
         runs-on: ubuntu-latest
 
+        env:
+          GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
         steps:
         - uses: actions/checkout@v4
 

--- a/ape-config.yaml
+++ b/ape-config.yaml
@@ -1,0 +1,11 @@
+plugins:
+  - name: foundry
+
+tokens:
+  default: "CoinGecko"
+  required:
+    - name: "CoinGecko"
+      uri: "https://tokens.coingecko.com/uniswap/all.json"
+
+ethereum:
+  default_network: mainnet-fork

--- a/ape_tokens/config.py
+++ b/ape_tokens/config.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from ape.api import PluginConfig
 from pydantic import BaseModel
 from pydantic_settings import SettingsConfigDict
@@ -12,7 +14,7 @@ class ListInfo(BaseModel):
 
 
 class TokensConfig(PluginConfig):
-    default: str | None = None
+    default: Optional[str] = None
     required: list[ListInfo] = []
 
     model_config = SettingsConfigDict(env_prefix="APE_TOKENS_")

--- a/ape_tokens/managers.py
+++ b/ape_tokens/managers.py
@@ -1,12 +1,10 @@
 from typing import TYPE_CHECKING
 
-from ape.exceptions import ContractNotFoundError
 from ape.logging import get_logger
 from ape.utils import ManagerAccessMixin, cached_property
-from eth_utils import to_checksum_address
 from tokenlists import TokenListManager
 
-from .types import ERC20
+from .types import TokenInstance
 
 if TYPE_CHECKING:
     from ape.contracts import ContractInstance
@@ -55,10 +53,4 @@ class TokenManager(ManagerAccessMixin, dict):
         except ValueError as err:
             raise KeyError(f"Symbol '{symbol}' is not a known token symbol") from err
 
-        checksummed_address = to_checksum_address(token_info.address)
-        try:
-            return self.chain_manager.contracts.instance_at(checksummed_address)
-        except ContractNotFoundError:
-            return self.chain_manager.contracts.instance_at(
-                checksummed_address, contract_type=ERC20
-            )
+        return TokenInstance.from_tokeninfo(token_info)

--- a/ape_tokens/types.py
+++ b/ape_tokens/types.py
@@ -155,6 +155,8 @@ class TokenInstance(ContractInstance):
         contract_instance = cls.chain_manager.contracts.instance_at(
             checksummed_address,
             contract_type=ERC20,
+            # NOTE: Use default setting for proxy detection as we don't
+            #       know if token is proxy (e.g. USDC)
         )
         contract_instance.__class__ = cls
         contract_instance._token_info = token_info

--- a/ape_tokens/types.py
+++ b/ape_tokens/types.py
@@ -1,4 +1,10 @@
+from typing import Any
+
+from ape.contracts.base import ContractCallHandler, ContractInstance
 from ape.types import ContractType
+from ape.utils import ManagerAccessMixin, cached_property
+from eth_utils import to_checksum_address
+from tokenlists import TokenInfo
 
 ERC20 = ContractType.model_validate(
     {
@@ -99,3 +105,57 @@ ERC20 = ContractType.model_validate(
         ],
     }
 )
+
+
+class CachedCallHandler(ContractCallHandler):
+    _cached_value: Any
+
+    def __call__(self, *args: Any, **kwds: Any) -> Any:
+        return self._cached_value
+
+
+class TokenInstance(ContractInstance, ManagerAccessMixin):
+    # NOTE: Subclass this so that we don't create a breaking interface (still is a ContractInstance)
+    _token_info: TokenInfo | None = None
+
+    # Cached "immutable" method calls (skip RPC request, return cached token info)
+    @cached_property
+    def name(self) -> ContractCallHandler:
+        assert self._token_info  # mypy happy
+        name_method = self._view_methods_["name"]
+        name_method.__class__ = CachedCallHandler
+        name_method.__doc__ = """The name of the token (sourced from 'py-tokenlists')"""
+        name_method._cached_value = self._token_info.name
+        return name_method
+
+    @cached_property
+    def symbol(self) -> ContractCallHandler:
+        assert self._token_info  # mypy happy
+        symbol_method = self._view_methods_["symbol"]
+        symbol_method.__class__ = CachedCallHandler
+        symbol_method.__doc__ = """The symbol of the token (sourced from 'py-tokenlists')"""
+        symbol_method._cached_value = self._token_info.symbol
+        return symbol_method
+
+    @cached_property
+    def decimals(self) -> ContractCallHandler:
+        assert self._token_info  # mypy happy
+        decimals_method = self._view_methods_["decimals"]
+        decimals_method.__class__ = CachedCallHandler
+        decimals_method.__doc__ = """The decimals of the token (sourced from 'py-tokenlists')"""
+        decimals_method._cached_value = self._token_info.decimals
+        return decimals_method
+
+    def __repr__(self) -> str:
+        return f"<{self.symbol()} {self.address}>"
+
+    @classmethod
+    def from_tokeninfo(cls, token_info: "TokenInfo"):
+        checksummed_address = to_checksum_address(token_info.address)
+        contract_instance = cls.chain_manager.contracts.instance_at(
+            checksummed_address,
+            contract_type=ERC20,
+        )
+        contract_instance.__class__ = cls
+        contract_instance._token_info = token_info
+        return contract_instance

--- a/ape_tokens/types.py
+++ b/ape_tokens/types.py
@@ -125,7 +125,7 @@ class TokenInstance(ContractInstance, ManagerAccessMixin):
         name_method = self._view_methods_["name"]
         name_method.__class__ = CachedCallHandler
         name_method.__doc__ = """The name of the token (sourced from 'py-tokenlists')"""
-        name_method._cached_value = self._token_info.name
+        name_method._cached_value = self._token_info.name  # type: ignore[attr-defined]
         return name_method
 
     @cached_property
@@ -134,7 +134,7 @@ class TokenInstance(ContractInstance, ManagerAccessMixin):
         symbol_method = self._view_methods_["symbol"]
         symbol_method.__class__ = CachedCallHandler
         symbol_method.__doc__ = """The symbol of the token (sourced from 'py-tokenlists')"""
-        symbol_method._cached_value = self._token_info.symbol
+        symbol_method._cached_value = self._token_info.symbol  # type: ignore[attr-defined]
         return symbol_method
 
     @cached_property
@@ -143,7 +143,7 @@ class TokenInstance(ContractInstance, ManagerAccessMixin):
         decimals_method = self._view_methods_["decimals"]
         decimals_method.__class__ = CachedCallHandler
         decimals_method.__doc__ = """The decimals of the token (sourced from 'py-tokenlists')"""
-        decimals_method._cached_value = self._token_info.decimals
+        decimals_method._cached_value = self._token_info.decimals  # type: ignore[attr-defined]
         return decimals_method
 
     def __repr__(self) -> str:

--- a/ape_tokens/types.py
+++ b/ape_tokens/types.py
@@ -2,7 +2,7 @@ from typing import Any
 
 from ape.contracts.base import ContractCallHandler, ContractInstance
 from ape.types import ContractType
-from ape.utils import ManagerAccessMixin, cached_property
+from ape.utils import cached_property
 from eth_utils import to_checksum_address
 from tokenlists import TokenInfo
 
@@ -114,7 +114,7 @@ class CachedCallHandler(ContractCallHandler):
         return self._cached_value
 
 
-class TokenInstance(ContractInstance, ManagerAccessMixin):
+class TokenInstance(ContractInstance):
     # NOTE: Subclass this so that we don't create a breaking interface (still is a ContractInstance)
     _token_info: TokenInfo | None = None
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,8 +20,6 @@ include = '\.pyi?$'
 
 [tool.pytest.ini_options]
 addopts = """
-    -p no:ape_test
-    -p no:pytest_ethereum
     --cov-branch
     --cov-report term
     --cov-report html

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,8 @@ include = '\.pyi?$'
 
 [tool.pytest.ini_options]
 addopts = """
+    -p no:boa_test
+    -p no:pytest_ethereum
     --cov-branch
     --cov-report term
     --cov-report html

--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -1,3 +1,5 @@
+from ape.contracts import ContractInstance
+
 from ape_tokens import tokens
 
 
@@ -8,3 +10,17 @@ def test_tokens():
     from ape_tokens import tokens as tokens2
 
     assert id(tokens2) == id(tokens)
+
+
+def test_immutable():
+    # Test if we are able to access tokens as `ContractInstance` objects
+    # NOTE: Also checks our Ape config loading feature
+    usdc = tokens["USDC"]
+    assert isinstance(usdc, ContractInstance)
+    # NOTE: Canonical address of USDC on Ethereum Mainnet
+    assert usdc.address == "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+
+    # Test our "immutable" call logic doesn't break things
+    # NOTE: the `name` is actually incorrect w/ `CoinGecko` tokenlist
+    assert usdc.symbol() == "USDC"
+    assert usdc.decimals() == 6


### PR DESCRIPTION
### What I did

Per ERC20 spec, the `name`, `symbol`, and `decimals` method of a token should be immutable. Since we have already loaded them from disk using this plugin, let's just complete the loop and avoid making calls to tokens in our token list

### How I did it

`ape console -v DEBUG -c "from ape_tokens import tokens; usdc = tokens['USDC']; usdc.symbol()"`

### How to verify it

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
~~- [ ] New test cases have been added and are passing~~
~~- [ ] Documentation has been updated~~
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
