### PR TITLE
fix: handle `decode=False` in immutable call handler

### DIFF
--- a/ape_tokens/types.py
+++ b/ape_tokens/types.py
@@ -115,7 +115,7 @@ class ImmutableCallHandler(ContractCallHandler):
     _cached_raw_value: Optional[HexBytes] = None
 
     def __call__(self, *args: Any, **kwargs: Any) -> Any:
-        if kwargs.get("decode", False):
+        if kwargs.get("decode", True):
             if not hasattr(self, "_cached_value"):
                 self._cached_value = super().__call__(*args, **kwargs)
 

--- a/ape_tokens/types.py
+++ b/ape_tokens/types.py
@@ -1,7 +1,8 @@
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, Optional, cast
 
 from ape.contracts.base import ContractCallHandler, ContractContainer, ContractInstance
 from ape.types import ContractType
+from eth_pydantic_types import HexBytes
 from eth_utils import to_checksum_address
 
 if TYPE_CHECKING:
@@ -111,12 +112,20 @@ ERC20 = ContractType.model_validate(
 class ImmutableCallHandler(ContractCallHandler):
     # TODO: Should this move upstream into Ape as `ImmutableCallHandler`?
     _cached_value: Any
+    _cached_raw_value: Optional[HexBytes] = None
 
     def __call__(self, *args: Any, **kwargs: Any) -> Any:
-        if not hasattr(self, "_cached_value"):
-            self._cached_value = super().__call__(*args, **kwargs)
+        decode = kwargs.get("decode", False)
+        if decode:
+            if not hasattr(self, "_cached_value"):
+                self._cached_value = super().__call__(*args, **kwargs)
 
-        return self._cached_value
+            return self._cached_value
+
+        elif self._cached_raw_value is None:
+            self._cached_raw_value = super().__call__(*args, **kwargs)
+
+        return self._cached_raw_value
 
 
 class TokenInstance(ContractInstance):

--- a/ape_tokens/types.py
+++ b/ape_tokens/types.py
@@ -115,8 +115,7 @@ class ImmutableCallHandler(ContractCallHandler):
     _cached_raw_value: Optional[HexBytes] = None
 
     def __call__(self, *args: Any, **kwargs: Any) -> Any:
-        decode = kwargs.get("decode", False)
-        if decode:
+        if kwargs.get("decode", False):
             if not hasattr(self, "_cached_value"):
                 self._cached_value = super().__call__(*args, **kwargs)
 

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ extras_require = {
         "pytest-xdist",  # Multi-process runner
         "pytest-cov",  # Coverage analyzer plugin
         "hypothesis>=6.2.0,<7.0",  # Strategy-based fuzzer
+        "ape-foundry>=0.8.8,<0.9"
     ],
     "lint": [
         "black>=24.10.0,<25",  # Auto-formatter and linter

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ extras_require = {
         "pytest-xdist",  # Multi-process runner
         "pytest-cov",  # Coverage analyzer plugin
         "hypothesis>=6.2.0,<7.0",  # Strategy-based fuzzer
-        "ape-foundry>=0.8.8,<0.9"
+        "ape-foundry>=0.8.9,<0.9",
     ],
     "lint": [
         "black>=24.10.0,<25",  # Auto-formatter and linter

--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -1,4 +1,5 @@
 from ape.contracts import ContractInstance
+from eth_pydantic_types import HexBytes
 
 from ape_tokens import tokens
 
@@ -24,6 +25,9 @@ def test_immutable():
     # NOTE: the `name` is actually incorrect w/ `CoinGecko` tokenlist
     assert usdc.symbol() == "USDC"
     assert usdc.decimals() == 6
+    assert usdc.decimals(decode=False) == HexBytes(
+        "0x0000000000000000000000000000000000000000000000000000000000000006"
+    )
 
 
 def test_getattr():


### PR DESCRIPTION
### What I did

fixes: #57 
Honors the core `decode=False` arg for getting raw returndata in calls in the `ImmutableCallHandler`

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
